### PR TITLE
attempts to resolve: #43

### DIFF
--- a/barcode/lib/src/barcode.dart
+++ b/barcode/lib/src/barcode.dart
@@ -504,7 +504,7 @@ abstract class Barcode {
 
   /// Check if the Barcode is valid
   @nonVirtual
-  bool isValid(String data) => isValidBytes(utf8.encoder.convert(data));
+  bool isValid(String data) => isValidBytes(Uint8List.fromList(data.codeUnits));
 
   /// Check if the Barcode is valid
   @nonVirtual
@@ -521,7 +521,7 @@ abstract class Barcode {
   /// Check if the Barcode is valid. Throws [BarcodeException] with a proper
   /// message in case of error
   @nonVirtual
-  void verify(String data) => verifyBytes(utf8.encoder.convert(data));
+  void verify(String data) => verifyBytes(Uint8List.fromList(data.codeUnits));
 
   /// Check if the Barcode is valid. Throws [BarcodeException] with a proper
   /// message in case of error

--- a/barcode/lib/src/datamatrix.dart
+++ b/barcode/lib/src/datamatrix.dart
@@ -78,22 +78,27 @@ class BarcodeDataMatrix extends Barcode2D {
       final c = input[i];
       i++;
 
-      if (c >= 0x30 &&
-          c <= 0x39 &&
-          i < input.length &&
-          input[i] >= 0x30 &&
-          input[i] <= 0x39) {
-        // two numbers...
-        final c2 = input[i];
-        i++;
-        final cw = ((c - 0x30) * 10 + (c2 - 0x30)) + 130;
-        result.add(cw);
-      } else if (c > 127) {
-        // not correct... needs to be redone later...
-        result.add(235);
-        result.add(c - 127);
+      // allow GS1 <FNC1> (char 232) to pass-through
+      if (c == 232) {
+        result.add(c);
       } else {
-        result.add(c + 1);
+        if (c >= 0x30 &&
+            c <= 0x39 &&
+            i < input.length &&
+            input[i] >= 0x30 &&
+            input[i] <= 0x39) {
+          // two numbers...
+          final c2 = input[i];
+          i++;
+          final cw = ((c - 0x30) * 10 + (c2 - 0x30)) + 130;
+          result.add(cw);
+        } else if (c > 127) {
+          // not correct... needs to be redone later...
+          result.add(235);
+          result.add(c - 127);
+        } else {
+          result.add(c + 1);
+        }
       }
     }
     return result;

--- a/flutter/lib/src/widget.dart
+++ b/flutter/lib/src/widget.dart
@@ -46,7 +46,7 @@ class BarcodeWidget extends StatelessWidget {
     BarcodeErrorBuilder? errorBuilder,
   }) =>
       BarcodeWidget.fromBytes(
-        data: utf8.encoder.convert(data),
+        data: Uint8List.fromList(data.codeUnits),
         barcode: barcode,
         color: color,
         backgroundColor: backgroundColor,


### PR DESCRIPTION
## What?
Attempts to resolve: #43
## Why?
To allow barcode DataMatrix to support GS1 \<FNC1\> char [232]
## How?
Replaced 3 instances of utf8.encoder.convert(data) with the more basic Uint8List.fromList(data.codeUnits) and modified _encodeText to allow the pass-through of char [232]
## Testing?
Run Barcode Demo (with DataMatrix selected) and enter
è01093396871955653922001188è3103000540è8008220331124400

Decode the symbol using Barcode Data Decoder Verifier by IDAutomation.

Decoder output *before* the change (**not** GS1 compliant): Ã¨01093396871955653922001188Ã¨3103000540Ã¨8008220331124400

Decoder output *after* the change (GS1 compliant): 
\<FNC1\>01093396871955653922001188\<GS\>3103000540\<GS\>8008220331124400

## Concerns?
I'm worried removing the utf-8 conversion will break applications which utilise non-ascii character sets (but I don't know how to fix that)