### PR TITLE
Fix invalid UPC-E in some cases

### DIFF
--- a/barcode/CHANGELOG.md
+++ b/barcode/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.6
+
+- Fix invalid UPC-E in some cases [shinbin]
+
 ## 2.2.5
 
 - Fix EAN2 incorrect encoding issue [shinbin]

--- a/barcode/pubspec.yaml
+++ b/barcode/pubspec.yaml
@@ -5,7 +5,7 @@ description: >-
 homepage: https://github.com/DavBfr/dart_barcode/tree/master/barcode
 repository: https://github.com/DavBfr/dart_barcode
 issue_tracker: https://github.com/DavBfr/dart_barcode/issues
-version: 2.2.5
+version: 2.2.6
 
 environment:
   sdk: ">=2.12.0 <4.0.0"

--- a/barcode/test/ean_test.dart
+++ b/barcode/test/ean_test.dart
@@ -137,6 +137,38 @@ void main() {
       throw Exception('upce is not a BarcodeEan');
     }
 
-    expect(upce.normalize('1'), equals('010000000009'));
+    expect(upce.normalize('1'), equals('01000009'));
+    expect(upce.normalize('555555'), equals('05555550'));
+    expect(upce.normalize('18740000015'), equals('18741538'));
+    expect(upce.normalize('48347295752'), equals('483472957520'));
+    expect(upce.normalize('212345678992'), equals('212345678992'));
+    expect(upce.normalize('014233365553'), equals('014233365553'));
+
+
+    final upce2 = Barcode.upcE(fallback: false);
+    if (upce2 is! BarcodeEan) {
+      throw Exception('upce is not a BarcodeEan');
+    }
+    expect(upce2.normalize('1'), equals('01000009'));
+
+    expect(upce2.normalize('01008029'), equals('01008029'));
+    expect(upce2.normalize('0100802'), equals('01008029'));
+    expect(upce2.normalize('100802'), equals('01008029'));
+
+    expect(upce2.normalize('100902'), equals('01009028'));
+    expect(upce2.normalize('100965'), equals('01009651'));
+    expect(upce2.normalize('107444'), equals('01074448'));
+
+    expect(upce2.normalize('042100005264'), equals('04252614'));
+    expect(upce2.normalize('020600000019'), equals('02060139'));
+    expect(upce2.normalize('040350000077'), equals('04035747'));
+    expect(upce2.normalize('020201000050'), equals('02020150'));
+    expect(upce2.normalize('020204000064'), equals('02020464'));
+    expect(upce2.normalize('023456000073'), equals('02345673'));
+    expect(upce2.normalize('020204000088'), equals('02020488'));
+    expect(upce2.normalize('020201000098'), equals('02020198'));
+    expect(upce2.normalize('127200002013'), equals('12720123'));
+    expect(upce2.normalize('042100005264'), equals('04252614'));
+
   });
 }

--- a/barcode/test/ean_test.dart
+++ b/barcode/test/ean_test.dart
@@ -138,37 +138,5 @@ void main() {
     }
 
     expect(upce.normalize('1'), equals('01000009'));
-    expect(upce.normalize('555555'), equals('05555550'));
-    expect(upce.normalize('18740000015'), equals('18741538'));
-    expect(upce.normalize('48347295752'), equals('483472957520'));
-    expect(upce.normalize('212345678992'), equals('212345678992'));
-    expect(upce.normalize('014233365553'), equals('014233365553'));
-
-
-    final upce2 = Barcode.upcE(fallback: false);
-    if (upce2 is! BarcodeEan) {
-      throw Exception('upce is not a BarcodeEan');
-    }
-    expect(upce2.normalize('1'), equals('01000009'));
-
-    expect(upce2.normalize('01008029'), equals('01008029'));
-    expect(upce2.normalize('0100802'), equals('01008029'));
-    expect(upce2.normalize('100802'), equals('01008029'));
-
-    expect(upce2.normalize('100902'), equals('01009028'));
-    expect(upce2.normalize('100965'), equals('01009651'));
-    expect(upce2.normalize('107444'), equals('01074448'));
-
-    expect(upce2.normalize('042100005264'), equals('04252614'));
-    expect(upce2.normalize('020600000019'), equals('02060139'));
-    expect(upce2.normalize('040350000077'), equals('04035747'));
-    expect(upce2.normalize('020201000050'), equals('02020150'));
-    expect(upce2.normalize('020204000064'), equals('02020464'));
-    expect(upce2.normalize('023456000073'), equals('02345673'));
-    expect(upce2.normalize('020204000088'), equals('02020488'));
-    expect(upce2.normalize('020201000098'), equals('02020198'));
-    expect(upce2.normalize('127200002013'), equals('12720123'));
-    expect(upce2.normalize('042100005264'), equals('04252614'));
-
   });
 }

--- a/barcode/test/upce_test.dart
+++ b/barcode/test/upce_test.dart
@@ -46,13 +46,16 @@ void main() {
       expect(bc.upcaToUpce('012100003454'), equals('123451'));
       expect(bc.upcaToUpce('012200003453'), equals('123452'));
       expect(bc.upcaToUpce('012300000451'), equals('123453'));
-      expect(bc.upcaToUpce('012340000053'), equals('123405'));
+      expect(bc.upcaToUpce('012340000053'), equals('123454'));
       expect(bc.upcaToUpce('012345000058'), equals('123455'));
       expect(bc.upcaToUpce('012345000065'), equals('123456'));
       expect(bc.upcaToUpce('012345000072'), equals('123457'));
       expect(bc.upcaToUpce('012345000089'), equals('123458'));
       expect(bc.upcaToUpce('012345000096'), equals('123459'));
+      expect(bc.upcaToUpce('000010000052'), equals('000154'));
+      expect(bc.upcaToUpce('010200000809'), equals('100802'));
     }
+    //For output data, please refer to https://barcodeqrcode.com/convert-upc-a-to-upc-e/
   });
 
   test('Barcode UPC-E', () {
@@ -63,4 +66,59 @@ void main() {
     expect(bc.isValid('11234593'), isTrue);
     expect(bc.isValid('123456789'), isFalse);
   });
+
+  test('Barcode UPC-E normalize (fallback)', () {
+    final bc = Barcode.upcE( fallback: true);
+    if (bc is BarcodeUpcE) {
+      expect(bc.normalize('18740000015'), equals('18741538'));
+      expect(bc.normalize('48347295752'), equals('483472957520'));
+      expect(bc.normalize('555555'), equals('05555550'));
+      expect(bc.normalize('212345678992'), equals('212345678992'));
+      expect(bc.normalize('014233365553'), equals('014233365553'));
+    }
+  });
+
+  test('Barcode UPC-E normalize', () {
+    final bc = Barcode.upcE();
+    if (bc is BarcodeUpcE) {
+      expect(bc.normalize('01008029'), equals('01008029'));
+      expect(bc.normalize('0100802'), equals('01008029'));
+      expect(bc.normalize('100802'), equals('01008029'));
+      expect(bc.normalize('1'), equals('01000009'));
+
+      expect(bc.normalize('100902'), equals('01009028'));
+      expect(bc.normalize('100965'), equals('01009651'));
+      expect(bc.normalize('107444'), equals('01074448'));
+      expect(bc.normalize('000100'), equals('00001009'));
+
+      expect(bc.normalize('042100005264'), equals('04252614'));
+      expect(bc.normalize('020600000019'), equals('02060139'));
+      expect(bc.normalize('040350000077'), equals('04035747'));
+      expect(bc.normalize('020201000050'), equals('02020150'));
+      expect(bc.normalize('020204000064'), equals('02020464'));
+      expect(bc.normalize('023456000073'), equals('02345673'));
+      expect(bc.normalize('020204000088'), equals('02020488'));
+      expect(bc.normalize('020201000098'), equals('02020198'));
+      expect(bc.normalize('127200002013'), equals('12720123'));
+      expect(bc.normalize('042100005264'), equals('04252614'));
+
+      //For special case : input '000105' etc.
+      //It's converted to '000010000052' ('L-MMMM0-0000P-C').
+      //This UPC-E code ends in 5, but its UPC-A manufacturer code is "00010" and its last digit should not be zero.
+      //'000010000052' should be paired with the last code of UPC-E being 4.
+      //'000010000052' converted to UPC-E will be '00001542'
+
+      //'000105' does not comply with the encoding principles for conversion from UPC-A to UPC-E,
+      //but it can applies to the conversion rules.
+      //It will be normalized to a new value when converting back to UPC-E.
+      //'000105' , '00001052' will be normalized to '00001542' , not '00001052'.
+      expect(bc.normalize('000105'), equals('00001542'));
+      expect(bc.normalize('00001052'), equals('00001542'));
+      expect(bc.normalize('000154'), equals('00001542'));
+      expect(bc.normalize('00001542'), equals('00001542'));
+      expect(bc.normalize('000010000052'), equals('00001542'));
+      expect(bc.normalize('001054'), equals('00000514')); //another special case
+    }
+  });
+
 }


### PR DESCRIPTION
Hi, DavBfr:
    I found an issue in UPC-E barcode and fixed it. 

One of the cases had a UPC-E input value of "100802" or "01008029".
The barcode content I expect to be displayed is "01008029" , as shown in the 1st picture, 
but it displays '01020089' and cannot be read by the barcode scanner , as shown in the 2nd picture.
There are also errors in other input values, such as 107444,100902,100965,555555,1.. etc.

The issue comes from upcaToUpce() , whose RegExp cannot split groups accurately. 
Please help to check and merge my fixed version.

Thanks.

OK, Test site :  [https://www.online-barcode.com/barcode-generator](url) or [https://barcodeqrcode.com/upc-e-generator/](url)
![upce_ok](https://github.com/DavBfr/dart_barcode/assets/12267647/b935c32b-3a94-44ba-b71d-2bf53b7b65b0)

NG, Test site : [https://davbfr.github.io/dart_barcode/#/](url)
![upce_ng](https://github.com/DavBfr/dart_barcode/assets/12267647/f325b7e4-05fa-407c-8c66-dc9e550c0ff0)


